### PR TITLE
Fixes for WebGL

### DIFF
--- a/Extensions/ObjectExtensions.cs
+++ b/Extensions/ObjectExtensions.cs
@@ -4,9 +4,26 @@ using System.Reflection;
 using System.Collections;
 using System.Text;
 using JsonFx.Json;
+using System.Linq;
 
 namespace Meteor.Extensions
 {
+
+	public static partial class DictExtensions
+	{
+		public static string DebugDict(this IDictionary dictionary)
+		{
+			var str = new StringBuilder();
+			str.Append("{");
+			foreach (var pair in dictionary.Cast<DictionaryEntry>())
+			{
+				str.Append(String.Format(" {0}={1} ", pair.Key, pair.Value));
+			}
+			str.Append("}");
+			return str.ToString();
+		}
+	}
+
 	public static partial class ObjectExtensions
 	{
 		static void DateSerializer (JsonFx.Json.JsonWriter writer, DateTime value)

--- a/LiveData/Exceptions.cs
+++ b/LiveData/Exceptions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Meteor {
+	public class MeteorException : System.Exception {
+		private int _code;
+
+		int Code {
+			get {
+				return _code;
+			}
+		}
+
+		public MeteorException() : base()
+		{
+		}
+
+		public MeteorException(int code, String message) : base(message)
+		{
+			this._code = code;
+		}
+
+		public MeteorException(int code, String message, Exception innerException) : base(message, innerException)
+		{
+			this._code = code;
+		}
+
+		protected MeteorException(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+		}
+	}
+}

--- a/LiveData/Exceptions.cs.meta
+++ b/LiveData/Exceptions.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ea6dacf8683c94b58a71518039baf1b7
+timeCreated: 1485476676
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LiveData/ILiveData.cs
+++ b/LiveData/ILiveData.cs
@@ -12,6 +12,7 @@ namespace Meteor.Internal
 		Method Call (string methodName, params object[] arguments);
 		Method<TResponseType> Call<TResponseType> (string methodName, params object[] arguments);
 		Subscription Subscribe (string publishName, params object[] arguments);
-        int GetCurrentRequestId();
+		void Unsubscribe (string subId);
+		int GetCurrentRequestId();
     }
 }

--- a/LiveData/LiveData.cs
+++ b/LiveData/LiveData.cs
@@ -58,6 +58,21 @@ namespace Meteor.Internal
 			methods = new Dictionary<string, IMethod> ();
 
 			uniqueId = 1;
+
+			CoroutineHost.Instance.StartCoroutine (HeartbeatCoroutine ());
+		}
+
+		public IEnumerator HeartbeatCoroutine()
+		{
+			while (true) {
+				yield return new WaitForSeconds(10);
+				if (Connected) {
+					var message = (new PingMessage () {
+						id = string.Format ("ping-{0}", this.NextId ())
+					}).Serialize ();
+					Connector.Send (System.Text.Encoding.UTF8.GetBytes (message));
+				}
+			}
 		}
 
 		/// <summary>

--- a/LiveData/LiveData.cs
+++ b/LiveData/LiveData.cs
@@ -114,11 +114,11 @@ namespace Meteor.Internal
 				Connector.OnError -= HandleOnError;
 			}
 			Connector = new WebSocket (new Uri (url));
+			yield return Connector.Connect ();
 			connectorInstanceId = Connector.GetHashCode ();
 			Connector.OnClosed += HandleOnClosed;
 			Connector.OnError += HandleOnError;
 			CoroutineHost.Instance.StartCoroutine (Dispatcher ());
-			yield return Connector.Connect ();
 			SendConnectMessage ();
 
 			while (!Connected) {

--- a/LiveData/LiveData.cs
+++ b/LiveData/LiveData.cs
@@ -409,6 +409,12 @@ namespace Meteor.Internal
 			case ResultMessage.result:
 				ResultMessage resultm = null;
 				resultm = socketMessage.Deserialize<ResultMessage> ();
+				if (resultm.methodError != null) {
+					int code = (int)resultm.methodError["error"];
+					string reason = (string)resultm.methodError["reason"];
+					string type = (string)resultm.methodError["errorType"];
+					throw new MeteorException (code, reason);
+				}
 				if (methods.ContainsKey (resultm.id)) {
 					methods [resultm.id].Callback (resultm.error, resultm.methodResult);
 				} else {
@@ -433,6 +439,17 @@ namespace Meteor.Internal
 				Send (pongMessage);
 				break;
 			case PongMessage.pong:
+				break;
+			case NosubMessage.nosub:
+				NosubMessage nosubm = null;
+				nosubm = socketMessage.Deserialize<NosubMessage> ();
+				if (nosubm.Error != null) {
+					string id = nosubm.id;
+					int code = (int)nosubm.Error["error"];
+					string reason = (string)nosubm.Error["reason"];
+					string type = (string)nosubm.Error["errorType"];
+					throw new MeteorException (code, reason);
+				}
 				break;
 			default:
 				if (!socketMessage.Contains ("server_id")) {

--- a/LiveData/LiveData.cs
+++ b/LiveData/LiveData.cs
@@ -297,6 +297,13 @@ namespace Meteor.Internal
 			return Subscriptions [requestId];
 		}
 
+		public void Unsubscribe (string subId)
+		{
+			Send (new UnsubscribeMessage () {
+				id = subId
+			});
+		}
+
 		#endregion
 
 		private int NextId ()

--- a/LiveData/Messages/NosubMessage.cs
+++ b/LiveData/Messages/NosubMessage.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+
+namespace Meteor.Internal
+{
+	internal class NosubMessage : Message
+	{
+		public const string nosub = "nosub";
+
+		[JsonFx.Json.JsonName("id")]
+		public string id;
+
+		[JsonFx.Json.JsonName("error")]
+		public Hashtable Error;
+
+		public NosubMessage()
+		{
+			msg = nosub;
+		}
+	}
+}
+

--- a/LiveData/Messages/NosubMessage.cs.meta
+++ b/LiveData/Messages/NosubMessage.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7fd7e42fdbd5b4402bcadda5acbefbe7
+timeCreated: 1485479759
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LiveData/Messages/ResultMessage.cs
+++ b/LiveData/Messages/ResultMessage.cs
@@ -17,6 +17,9 @@ namespace Meteor.Internal
 		[JsonFx.Json.JsonName("result")]
 		public object methodResult;
 
+		[JsonFx.Json.JsonName("error")]
+		public Hashtable methodError;
+
 		public ResultMessage ()
 		{
 			msg = result;

--- a/LiveData/Subscription.cs
+++ b/LiveData/Subscription.cs
@@ -69,6 +69,14 @@ namespace Meteor
 			return LiveData.Instance.Subscribe (name, args);
 		}
 
+		public static void Unsubscribe(Subscription sub) {
+			LiveData.Instance.Unsubscribe (sub.requestId);
+		}
+
+		public static void Unsubscribe(string subId) {
+			LiveData.Instance.Unsubscribe (subId);
+		}
+
 		public Subscription ()
 		{
 		}

--- a/Plugins/WebSocket.jslib
+++ b/Plugins/WebSocket.jslib
@@ -28,6 +28,14 @@ SocketCreate: function(url)
 		{
 			var array = new Uint8Array(e.data);
 			socket.messages.push(array);
+		} else if(typeof e.data === "string") {
+			var reader = new FileReader();
+			reader.addEventListener("loadend", function() {
+				var array = new Uint8Array(reader.result);
+				socket.messages.push(array);
+			});
+			var blob = new Blob([e.data]);
+			reader.readAsArrayBuffer(blob);
 		}
 	};
 
@@ -93,7 +101,7 @@ SocketSend: function (socketInstance, ptr, length)
 SocketRecvLength: function(socketInstance)
 {
 	var socket = webSocketInstances[socketInstance];
-	if (socket.messages.length == 0)
+	if (!socket || socket.messages.length == 0)
 		return 0;
 	return socket.messages[0].length;
 },


### PR DESCRIPTION
Here are some hacks that made a WebGL build work for me.  I can't guarantee they'll work for all situations.

The main issue I ran into was the placement of the `Connector.Connect()` call.  `Connector.GetHashCode()` calls a receive on the socket, and if the connection has not yet been established it triggers an error as the socket doesn't exist.  I'm not sure if there were any particular reason `Connect()` is placed after this, but moving it seems to fix it.

The other issue I had was that data was being received as a raw string, which isn't implemented by the Unity WebSocket js lib.  Applying the fix mentioned in the comments on the asset store page (https://www.assetstore.unity3d.com/en/#!/content/38367) solves that one.
